### PR TITLE
Remove pytest PyPI classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     # List at https://pypi.org/pypi?%3Aaction=list_classifiers
     Development Status :: 5 - Production/Stable
     Framework :: AsyncIO
-    Framework :: Pytest
     Intended Audience :: Developers
     Intended Audience :: End Users/Desktop
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)


### PR DESCRIPTION
The classifier is [intended for pytest plugins](https://docs.pytest.org/en/latest/writing_plugins.html#making-your-plugin-installable-by-others) and causes this project [to be listed](http://plugincompat.herokuapp.com/) in an autogenerated list of pytest plugins.